### PR TITLE
Add React Tailwind CDN modular example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# rextr
+# React Tailwind CDN Modular Example
+
+This example demonstrates a small modular React application that uses Tailwind CSS via CDN.
+
+## Usage
+
+Open `index.html` in your browser. All dependencies are loaded from CDNs, so no build step is required.

--- a/components/App.js
+++ b/components/App.js
@@ -1,0 +1,12 @@
+import React from "https://esm.sh/react@18";
+import Header from "./Header.js";
+import Button from "./Button.js";
+
+export default function App() {
+  return React.createElement(
+    "div",
+    { className: "p-4 space-y-4" },
+    React.createElement(Header, null),
+    React.createElement(Button, { label: "Click me" })
+  );
+}

--- a/components/Button.js
+++ b/components/Button.js
@@ -1,0 +1,9 @@
+import React from "https://esm.sh/react@18";
+
+export default function Button({ label }) {
+  return React.createElement(
+    "button",
+    { className: "px-4 py-2 bg-blue-500 text-white rounded" },
+    label
+  );
+}

--- a/components/Header.js
+++ b/components/Header.js
@@ -1,0 +1,9 @@
+import React from "https://esm.sh/react@18";
+
+export default function Header() {
+  return React.createElement(
+    "h1",
+    { className: "text-2xl font-bold text-blue-500" },
+    "Hello Tailwind CDN Modular"
+  );
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>React Tailwind CDN Modular</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100">
+  <div id="root"></div>
+  <script type="module" src="./main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,7 @@
+import React from "https://esm.sh/react@18";
+import ReactDOM from "https://esm.sh/react-dom@18/client";
+import App from "./components/App.js";
+
+ReactDOM.createRoot(document.getElementById("root")).render(
+  React.createElement(App)
+);


### PR DESCRIPTION
## Summary
- add a simple React app using Tailwind CSS via CDN
- demonstrate modular component structure without build tooling

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68aff12f01dc8320af378092876ca5f2